### PR TITLE
Refactor MLXModelService to Singleton and Improve File Detection Logic

### DIFF
--- a/Web/AI/Models/AIAssistant.swift
+++ b/Web/AI/Models/AIAssistant.swift
@@ -52,7 +52,7 @@ class AIAssistant: ObservableObject {
         self.aiConfiguration = HardwareDetector.getOptimalAIConfiguration()
 
         // Initialize MLX service and Gemma service after super.init equivalent
-        self.mlxModelService = MLXModelService()
+        self.mlxModelService = MLXModelService.shared
         self.gemmaService = GemmaService(
             configuration: aiConfiguration,
             mlxWrapper: mlxWrapper,

--- a/Web/AI/Services/LocalMLXProvider.swift
+++ b/Web/AI/Services/LocalMLXProvider.swift
@@ -62,7 +62,7 @@ class LocalMLXProvider: AIProvider, ObservableObject {
         // Initialize dependencies (reuse existing services)
         self.mlxWrapper = MLXWrapper()
         self.privacyManager = PrivacyManager()
-        self.mlxModelService = MLXModelService()
+        self.mlxModelService = MLXModelService.shared
 
         // Get optimal configuration for current hardware
         self.aiConfiguration = HardwareDetector.getOptimalAIConfiguration()

--- a/Web/AI/Services/MLXModelService.swift
+++ b/Web/AI/Services/MLXModelService.swift
@@ -6,8 +6,13 @@ import MLXLMCommon
 
 /// MLX-based model service for efficient app distribution
 /// Leverages MLX's built-in Hugging Face model downloading and caching
+/// Singleton pattern ensures consistent state across the app
 class MLXModelService: ObservableObject {
-
+    
+    // MARK: - Singleton
+    
+    static let shared = MLXModelService()
+    
     // MARK: - Published Properties
 
     @Published var isModelReady: Bool = false
@@ -48,31 +53,31 @@ class MLXModelService: ObservableObject {
 
     // MARK: - Initialization
 
-    init() {
+    private init() {
         // Use NSLog for critical debugging that always shows
-        NSLog("🚀 [CRITICAL] MLXModelService INITIALIZATION STARTED")
-        AppLog.debug("🚀 [INIT] === MLXModelService INITIALIZATION STARTED ===")
+        NSLog("🚀 [CRITICAL] MLXModelService SINGLETON INITIALIZATION STARTED")
+        AppLog.debug("🚀 [INIT] === MLXModelService SINGLETON INITIALIZATION STARTED ===")
 
         // Set default model configuration
         Task { @MainActor in
             currentModel = MLXModelConfiguration.gemma3_2B_4bit
-            NSLog("🚀 [CRITICAL] Default model configuration set: gemma3_2B_4bit")
-            AppLog.debug("🚀 [INIT] Default model configuration set: gemma3_2B_4bit")
+            NSLog("🚀 [CRITICAL] Singleton - Default model configuration set: gemma3_2B_4bit")
+            AppLog.debug("🚀 [INIT] Singleton - Default model configuration set: gemma3_2B_4bit")
         }
 
         // Smart startup initialization - check for existing models and manual downloads
         Task {
-            NSLog("🚀 [CRITICAL] Starting smart startup initialization task...")
-            AppLog.debug("🚀 [INIT] Starting smart startup initialization task...")
+            NSLog("🚀 [CRITICAL] Singleton - Starting smart startup initialization task...")
+            AppLog.debug("🚀 [INIT] Singleton - Starting smart startup initialization task...")
             await performSmartStartupInitialization()
-            NSLog("🚀 [CRITICAL] Smart startup initialization task completed")
-            AppLog.debug("🚀 [INIT] Smart startup initialization task completed")
+            NSLog("🚀 [CRITICAL] Singleton - Smart startup initialization task completed")
+            AppLog.debug("🚀 [INIT] Singleton - Smart startup initialization task completed")
         }
 
         NSLog(
-            "🚀 [CRITICAL] MLXModelService init completed - smart startup initialization scheduled")
+            "🚀 [CRITICAL] MLXModelService singleton init completed - smart startup initialization scheduled")
         AppLog.debug(
-            "🚀 [INIT] MLXModelService init completed - smart startup initialization scheduled")
+            "🚀 [INIT] MLXModelService singleton init completed - smart startup initialization scheduled")
     }
 
     deinit {

--- a/Web/AI/Utils/MLXCacheManager.swift
+++ b/Web/AI/Utils/MLXCacheManager.swift
@@ -76,29 +76,8 @@ class MLXCacheManager {
         }
         AppLog.debug("🚀 [SMART INIT] ❌ No lock file found")
 
-        // Simplified process check to prevent hanging
-        AppLog.debug("🚀 [SMART INIT] Performing simplified process check...")
-        do {
-            let task = Process()
-            task.launchPath = "/usr/bin/pgrep"
-            task.arguments = ["-f", "manual_model_download"]
-            
-            let pipe = Pipe()
-            task.standardOutput = pipe
-            task.standardError = Pipe() // Capture stderr to prevent output
-            
-            try task.run()
-            task.waitUntilExit()
-            
-            if task.terminationStatus == 0 {
-                AppLog.debug("🚀 [SMART INIT] ✅ Manual download script detected via pgrep - deferring initialization")
-                return true
-            } else {
-                AppLog.debug("🚀 [SMART INIT] ❌ No manual download script processes found")
-            }
-        } catch {
-            AppLog.debug("🚀 [SMART INIT] ❌ Could not check processes: \(error.localizedDescription)")
-        }
+        // Skip process check to avoid false positives - rely on lock file only
+        AppLog.debug("🚀 [SMART INIT] Skipping process check - lock file detection is more reliable")
         
         AppLog.debug("🚀 [SMART INIT] ✅ No manual download activity detected - proceeding with app initialization")
         return false


### PR DESCRIPTION
## Summary
- Refactored `MLXModelService` to use a singleton pattern for consistent state management across the app
- Updated `AIAssistant` and `LocalMLXProvider` to use the shared singleton instance of `MLXModelService`
- Simplified file detection logic in `MLXCacheManager` by removing unreliable process checks and relying solely on lock file detection

## Changes

### MLXModelService
- Converted `MLXModelService` initializer to private and added a static shared instance
- Updated initialization logs to reflect singleton usage
- Ensured smart startup initialization runs once per app lifecycle

### AIAssistant & LocalMLXProvider
- Replaced direct instantiation of `MLXModelService` with the singleton shared instance

### MLXCacheManager
- Removed process check for manual model download scripts to avoid false positives
- Relied exclusively on lock file presence for detecting manual download activity
- Added debug logs to clarify the simplified detection approach

## Test plan
- [x] Verify that `MLXModelService` is instantiated only once and shared correctly
- [x] Confirm that AI assistant and local MLX provider use the singleton instance
- [x] Test that manual model download detection correctly defers initialization based on lock file only
- [x] Ensure no regressions in model loading and caching behavior
- [x] Validate logs reflect the new singleton initialization and detection logic

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/902e6fa0-dfab-4704-b41a-5eb5349137f4

## Summary by Sourcery

Refactor MLXModelService into a singleton, update its consumers to use the shared instance, and streamline manual download detection in MLXCacheManager to rely solely on lock files.

Enhancements:
- Refactor MLXModelService to use a singleton pattern for consistent state management
- Update AIAssistant and LocalMLXProvider to use MLXModelService.shared instead of creating new instances
- Simplify MLXCacheManager’s manual download detection by removing process checks and relying on lock-file presence